### PR TITLE
Fix UUID field in DNSSEC key JSON

### DIFF
--- a/livedns/keys.go
+++ b/livedns/keys.go
@@ -5,7 +5,7 @@ import "github.com/tiramiseb/go-gandi/internal/client"
 // SigningKey holds data about a DNSSEC signing key
 type SigningKey struct {
 	Status        string `json:"status,omitempty"`
-	UUID          string `json:"uuid,omitempty"`
+	UUID          string `json:"id,omitempty"`
 	Algorithm     int    `json:"algorithm,omitempty"`
 	Deleted       *bool  `json:"deleted"`
 	AlgorithmName string `json:"algorithm_name,omitempty"`


### PR DESCRIPTION
Gandi are using `"id"`, not `"uuid"`, for their UUID fields.